### PR TITLE
Fix: Apply combo bonus to increment points

### DIFF
--- a/src/hooks/useGameState.tsx
+++ b/src/hooks/useGameState.tsx
@@ -11,6 +11,7 @@ interface GameState {
   activatedArtifacts: string[];
   secretUpgrades: string[];
   multiplier: number;
+  activeComboMultiplier: number;
 }
 
 const initialGameState: GameState = {
@@ -23,7 +24,8 @@ const initialGameState: GameState = {
   artifacts: [],
   activatedArtifacts: [],
   secretUpgrades: [],
-  multiplier: 1
+  multiplier: 1,
+  activeComboMultiplier: 1
 };
 
 export const useGameState = () => {
@@ -45,7 +47,7 @@ export const useGameState = () => {
   const handleClick = useCallback(() => {
     setGameState(prev => ({
       ...prev,
-      incrementPoints: prev.incrementPoints + (prev.clickPower * prev.multiplier),
+      incrementPoints: prev.incrementPoints + (prev.clickPower * prev.multiplier * prev.activeComboMultiplier),
       totalClicks: prev.totalClicks + 1
     }));
   }, []);
@@ -167,7 +169,7 @@ export const useGameState = () => {
   }, []);
 
   const handleComboBonus = useCallback((multiplier: number) => {
-    // Combo bonus is temporary and handled in the combo system
+    setGameState(prev => ({ ...prev, activeComboMultiplier: multiplier }));
   }, []);
 
   const loadGameState = useCallback((newState: Partial<GameState>) => {


### PR DESCRIPTION
Previously, the combo system calculated a score multiplier but this multiplier was not applied to your increment point generation during clicks. The UI indicated a bonus, but it had no effect on the core game mechanic.

This change implements the following:
- Added `activeComboMultiplier` to `useGameState` (defaulting to 1).
- `handleClick` in `useGameState` now incorporates this `activeComboMultiplier` into the points calculation: `points = clickPower * generalMultiplier * activeComboMultiplier`.
- `ComboSystem.tsx` now calls a callback (`onComboBonus`) with the current combo multiplier (e.g., 1.5 for 5x combo). This updates `activeComboMultiplier` in `useGameState`.
- When a combo ends (either by timer decay or component cleanup while active), `ComboSystem.tsx` calls `onComboBonus(1)` to reset the `activeComboMultiplier` in `useGameState` back to 1.

This ensures that combo bonuses correctly enhance point generation as implied by the game's UI and typical incremental game mechanics.